### PR TITLE
FF-408 use UTF-8 for Content-Type header

### DIFF
--- a/.run/RestApplication-dev.run.xml
+++ b/.run/RestApplication-dev.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="RestApplication[DEV]" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
-    <module name="RestApi" />
+    <module name="rest" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="de.filefighter.rest.RestApplication" />
     <option name="ACTIVE_PROFILES" value="dev" />
     <option name="ALTERNATIVE_JRE_PATH" />

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,8 @@
 server.servlet.context-path=/
 server.port=8080
 server.error.whitelabel.enabled=false
+server.servlet.encoding.charset=UTF-8
+server.servlet.encoding.force-response=true
 #------------------- LOGGING ---------------------
 logging.level.root=INFO
 logging.level.de.filefighter.rest=DEBUG


### PR DESCRIPTION
The FH needs this information to be able to parse the json response.

before: 

Content-Type: application/json


after: 
Content-Type: application/json;charset=UTF-8